### PR TITLE
Removed isolated scope.

### DIFF
--- a/angular-imgcache.js
+++ b/angular-imgcache.js
@@ -39,10 +39,6 @@ angular.module('ImgCache', [])
 
     return {
         restrict: 'A',
-        scope: {
-            icBg: '@',
-            icSrc: '@'
-        },
         link: function(scope, el, attrs) {
 
             var setImg = function(type, el, src) {


### PR DESCRIPTION
Indeed, it is limiting (impossibility to use two directives with isolated scope on the same element) and not necessary as attrs.$observe is used. It's probably an anti-pattern here.

http://www.bennadel.com/blog/2729-don-t-blindly-isolate-all-the-scopes-in-angularjs-directives.htm
